### PR TITLE
feat/self host page

### DIFF
--- a/src/routes/self-host/+page.svelte
+++ b/src/routes/self-host/+page.svelte
@@ -1,0 +1,433 @@
+<script lang="ts">
+  import Seo from '$lib/components/SEO.svelte';
+
+  let activePath = $state<'cvmi' | 'ts'>('cvmi');
+
+  // Orange accent — matches contextvm.org "Read docs" button
+  const ACCENT       = '#E8550A';
+  const ACCENT_LIGHT = '#FDE9DF';
+  const ACCENT_DARK  = '#A33A05';
+
+  function copyCode(text: string, btn: HTMLButtonElement) {
+    navigator.clipboard.writeText(text).then(() => {
+      btn.textContent = 'copied';
+      setTimeout(() => (btn.textContent = 'copy'), 1500);
+    }).catch(() => {
+      btn.textContent = 'copy';
+    });
+  }
+</script>
+
+<Seo
+  title="Self-Host a Server | ContextVM"
+  description="A complete guide to hosting a ContextVM server on the Nostr network. Choose your path — no-code CLI with CVMI or custom integration with the TypeScript SDK."
+/>
+
+<main class="sh-page">
+
+  <!-- ── Hero ─────────────────────────────────────────────────────── -->
+  <div class="sh-hero">
+    <div class="sh-badge" style="background:{ACCENT_LIGHT}; color:{ACCENT_DARK};">
+      Self-hosting guide
+    </div>
+    <h1 class="sh-h1">Host your own ContextVM server</h1>
+    <p class="sh-lead">
+      Expose any MCP server to the decentralised Nostr network in minutes.
+      Pick your path below.
+    </p>
+  </div>
+
+  <!-- ── Content ───────────────────────────────────────────────────── -->
+  <div class="sh-content">
+
+    <div class="sh-label">Choose your approach</div>
+
+    <!-- Path chooser -->
+    <div class="sh-chooser">
+      <button
+        class="sh-card"
+        style="border-color:{activePath === 'cvmi' ? ACCENT : 'rgba(128,128,128,0.25)'}; border-width:{activePath === 'cvmi' ? '2px' : '0.5px'};"
+        onclick={() => (activePath = 'cvmi')}
+      >
+        <div class="sh-icon">⚡</div>
+        <h3 class="sh-card-title">CVMI (CLI tool)</h3>
+        <p class="sh-card-desc">Quickest way to get a server running. No code required — just a terminal.</p>
+        <span class="sh-tag" style="background:{ACCENT_LIGHT}; color:{ACCENT_DARK};">Recommended for beginners</span>
+      </button>
+
+      <button
+        class="sh-card"
+        style="border-color:{activePath === 'ts' ? ACCENT : 'rgba(128,128,128,0.25)'}; border-width:{activePath === 'ts' ? '2px' : '0.5px'};"
+        onclick={() => (activePath = 'ts')}
+      >
+        <div class="sh-icon">🛠</div>
+        <h3 class="sh-card-title">TypeScript SDK</h3>
+        <p class="sh-card-desc">Build a custom server with full control over transport, keys, and behaviour.</p>
+        <span class="sh-tag" style="background:#E6F1FB; color:#185FA5;">For developers</span>
+      </button>
+    </div>
+
+    <!-- ── CVMI PATH ─────────────────────────────────────────────── -->
+    {#if activePath === 'cvmi'}
+      <div class="sh-label">Step-by-step — CVMI path</div>
+      <div class="sh-steps">
+
+        <div class="sh-step">
+          <div class="sh-step-line">
+            <div class="sh-num" style="background:{ACCENT}; color:#fff;">1</div>
+            <div class="sh-connector"></div>
+          </div>
+          <div class="sh-body">
+            <h4 class="sh-step-title">Check prerequisites</h4>
+            <p class="sh-step-desc">You need Node.js 18 or higher installed. That's it — no global installs required.</p>
+            <div class="sh-prereq-grid">
+              <div class="sh-prereq">
+                <div class="sh-check" style="background:{ACCENT};">
+                  <svg viewBox="0 0 10 10" fill="none" width="10" height="10">
+                    <polyline points="2,5 4,7.5 8,3" stroke="white" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+                  </svg>
+                </div>
+                Node.js 18 or higher
+              </div>
+              <div class="sh-prereq">
+                <div class="sh-check" style="background:{ACCENT};">
+                  <svg viewBox="0 0 10 10" fill="none" width="10" height="10">
+                    <polyline points="2,5 4,7.5 8,3" stroke="white" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+                  </svg>
+                </div>
+                npm, yarn, pnpm, or bun
+              </div>
+            </div>
+            <div class="sh-tip" style="background:{ACCENT_LIGHT}; border-left-color:{ACCENT}; color:{ACCENT_DARK};">
+              Check your Node version: <code style="color:{ACCENT_DARK}; font-family:monospace;">node --version</code>
+            </div>
+          </div>
+        </div>
+
+        <div class="sh-step">
+          <div class="sh-step-line">
+            <div class="sh-num" style="background:{ACCENT}; color:#fff;">2</div>
+            <div class="sh-connector"></div>
+          </div>
+          <div class="sh-body">
+            <h4 class="sh-step-title">Verify CVMI works</h4>
+            <p class="sh-step-desc">No installation needed. Run this once to confirm everything is set up correctly.</p>
+            <div class="sh-code">
+              <span>npx cvmi --help</span>
+              <button class="sh-copy" onclick={(e) => copyCode('npx cvmi --help', e.currentTarget)}>copy</button>
+            </div>
+            <div class="sh-tip" style="background:{ACCENT_LIGHT}; border-left-color:{ACCENT}; color:{ACCENT_DARK};">
+              You should see a list of available commands. If you do, you're ready.
+            </div>
+          </div>
+        </div>
+
+        <div class="sh-step">
+          <div class="sh-step-line">
+            <div class="sh-num" style="background:{ACCENT}; color:#fff;">3</div>
+            <div class="sh-connector"></div>
+          </div>
+          <div class="sh-body">
+            <h4 class="sh-step-title">Start your server</h4>
+            <p class="sh-step-desc">
+              This exposes a local filesystem MCP server to the Nostr network.
+              A cryptographic key pair is auto-generated for you.
+            </p>
+            <div class="sh-code">
+              <span>npx cvmi serve -- npx -y @modelcontextprotocol/server-filesystem /tmp</span>
+              <button class="sh-copy" onclick={(e) => copyCode('npx cvmi serve -- npx -y @modelcontextprotocol/server-filesystem /tmp', e.currentTarget)}>copy</button>
+            </div>
+            <div class="sh-tip" style="background:{ACCENT_LIGHT}; border-left-color:{ACCENT}; color:{ACCENT_DARK};">
+              Your server's public key (<code style="color:{ACCENT_DARK}; font-family:monospace;">npub1...</code>) will print in the terminal. Save it — you'll need it to connect clients.
+            </div>
+          </div>
+        </div>
+
+        <div class="sh-step">
+          <div class="sh-step-line">
+            <div class="sh-num" style="background:{ACCENT}; color:#fff;">4</div>
+            <div class="sh-connector"></div>
+          </div>
+          <div class="sh-body">
+            <h4 class="sh-step-title">Connect a client</h4>
+            <p class="sh-step-desc">From another machine or MCP client, connect using your server's public key.</p>
+            <div class="sh-code">
+              <span>npx cvmi use npub1q...</span>
+              <button class="sh-copy" onclick={(e) => copyCode('npx cvmi use npub1q...', e.currentTarget)}>copy</button>
+            </div>
+          </div>
+        </div>
+
+        <div class="sh-step">
+          <div class="sh-step-line">
+            <div class="sh-num" style="background:{ACCENT}; color:#fff;">5</div>
+            <div class="sh-connector"></div>
+          </div>
+          <div class="sh-body">
+            <h4 class="sh-step-title">Optional: configure your server</h4>
+            <p class="sh-step-desc">
+              Create a <code style="font-family:monospace;">.cvmi.json</code> in your project folder to set relays,
+              encryption, and a persistent private key.
+            </p>
+            <pre class="sh-code sh-pre">{`{
+  "serve": {
+    "privateKey": "nsec1...",
+    "relays": ["wss://relay.damus.io"],
+    "encryption": "required",
+    "public": true
+  }
+}`}</pre>
+            <div class="sh-tip" style="background:{ACCENT_LIGHT}; border-left-color:{ACCENT}; color:{ACCENT_DARK};">
+              Full reference:
+              <a href="https://docs.contextvm.org/cvmi/configuration/" target="_blank" rel="noopener"
+                style="color:{ACCENT_DARK}; font-weight:600;">
+                docs.contextvm.org/cvmi/configuration
+              </a>
+            </div>
+          </div>
+        </div>
+
+      </div>
+    {/if}
+
+    <!-- ── TYPESCRIPT SDK PATH ───────────────────────────────────── -->
+    {#if activePath === 'ts'}
+      <div class="sh-label">Step-by-step — TypeScript SDK path</div>
+      <div class="sh-steps">
+
+        <div class="sh-step">
+          <div class="sh-step-line">
+            <div class="sh-num" style="background:{ACCENT}; color:#fff;">1</div>
+            <div class="sh-connector"></div>
+          </div>
+          <div class="sh-body">
+            <h4 class="sh-step-title">Install the SDK</h4>
+            <p class="sh-step-desc">Add the ContextVM TypeScript SDK to your project.</p>
+            <div class="sh-code">
+              <span>npm install @contextvm/sdk</span>
+              <button class="sh-copy" onclick={(e) => copyCode('npm install @contextvm/sdk', e.currentTarget)}>copy</button>
+            </div>
+          </div>
+        </div>
+
+        <div class="sh-step">
+          <div class="sh-step-line">
+            <div class="sh-num" style="background:{ACCENT}; color:#fff;">2</div>
+            <div class="sh-connector"></div>
+          </div>
+          <div class="sh-body">
+            <h4 class="sh-step-title">Understand the core building blocks</h4>
+            <p class="sh-step-desc">
+              Before writing code, get familiar with the three concepts that power every
+              ContextVM integration: <strong>transports</strong>, <strong>signers</strong>,
+              and <strong>relay handlers</strong>.
+            </p>
+            <div class="sh-tip" style="background:{ACCENT_LIGHT}; border-left-color:{ACCENT}; color:{ACCENT_DARK};">
+              Start with the
+              <a href="https://docs.contextvm.org/ts-sdk/quick-overview/" target="_blank" rel="noopener"
+                style="color:{ACCENT_DARK}; font-weight:600;">SDK Quick Overview</a>
+              — it maps out what each module does and how they fit together.
+            </div>
+          </div>
+        </div>
+
+        <div class="sh-step">
+          <div class="sh-step-line">
+            <div class="sh-num" style="background:{ACCENT}; color:#fff;">3</div>
+            <div class="sh-connector"></div>
+          </div>
+          <div class="sh-body">
+            <h4 class="sh-step-title">Choose the right component for hosting</h4>
+            <p class="sh-step-desc">Two components handle the server side:</p>
+            <div class="sh-prereq-grid">
+              <div class="sh-prereq" style="flex-direction:column; align-items:flex-start; gap:4px;">
+                <strong style="font-size:13px;">NostrMCPGateway</strong>
+                <span>Exposes an existing MCP server to the Nostr network</span>
+              </div>
+              <div class="sh-prereq" style="flex-direction:column; align-items:flex-start; gap:4px;">
+                <strong style="font-size:13px;">NostrMCPProxy</strong>
+                <span>Bridges a Nostr server to a local stdio MCP client</span>
+              </div>
+            </div>
+            <div class="sh-tip" style="background:{ACCENT_LIGHT}; border-left-color:{ACCENT}; color:{ACCENT_DARK};">
+              See
+              <a href="https://docs.contextvm.org/ts-sdk/gateway/overview/" target="_blank" rel="noopener"
+                style="color:{ACCENT_DARK}; font-weight:600;">Gateway docs</a>
+              and
+              <a href="https://docs.contextvm.org/ts-sdk/proxy/overview/" target="_blank" rel="noopener"
+                style="color:{ACCENT_DARK}; font-weight:600;">Proxy docs</a>
+              for implementation details.
+            </div>
+          </div>
+        </div>
+
+        <div class="sh-step">
+          <div class="sh-step-line">
+            <div class="sh-num" style="background:{ACCENT}; color:#fff;">4</div>
+            <div class="sh-connector"></div>
+          </div>
+          <div class="sh-body">
+            <h4 class="sh-step-title">Run the client-server tutorial</h4>
+            <p class="sh-step-desc">
+              Work through the hands-on example to see a full server and client
+              interaction in TypeScript before writing your own.
+            </p>
+            <div class="sh-tip" style="background:{ACCENT_LIGHT}; border-left-color:{ACCENT}; color:{ACCENT_DARK};">
+              Found under Tutorials →
+              <a href="https://docs.contextvm.org/ts-sdk/tutorials/client-server-communication/"
+                target="_blank" rel="noopener"
+                style="color:{ACCENT_DARK}; font-weight:600;">Client-Server Communication</a>
+              in the docs sidebar.
+            </div>
+          </div>
+        </div>
+
+        <div class="sh-step">
+          <div class="sh-step-line">
+            <div class="sh-num" style="background:{ACCENT}; color:#fff;">5</div>
+            <div class="sh-connector"></div>
+          </div>
+          <div class="sh-body">
+            <h4 class="sh-step-title">Go live</h4>
+            <p class="sh-step-desc">
+              Once built, your server needs a Nostr private key and relay configuration
+              to go live on the network. Pass keys and relays directly into the SDK's
+              transport options.
+            </p>
+            <div class="sh-tip" style="background:{ACCENT_LIGHT}; border-left-color:{ACCENT}; color:{ACCENT_DARK};">
+              Want to charge clients for access? Set up
+              <a href="https://docs.contextvm.org/ts-sdk/payments/overview/" target="_blank" rel="noopener"
+                style="color:{ACCENT_DARK}; font-weight:600;">Lightning payments via CEP-8</a>.
+            </div>
+          </div>
+        </div>
+
+      </div>
+    {/if}
+
+    <hr class="sh-divider" />
+
+    <!-- What's next -->
+    <div class="sh-label">What's next</div>
+    <div class="sh-next-grid">
+      <div class="sh-next-card">
+        <h5 class="sh-next-title">Add skills</h5>
+        <p class="sh-next-desc">Install reference implementations and templates to accelerate development.</p>
+        <a class="sh-next-link" style="color:{ACCENT};"
+          href="https://docs.contextvm.org/cvmi/skills/overview/" target="_blank" rel="noopener">
+          Learn about skills →
+        </a>
+      </div>
+      <div class="sh-next-card">
+        <h5 class="sh-next-title">Publish your server</h5>
+        <p class="sh-next-desc">Make your server publicly discoverable on the Nostr network.</p>
+        <a class="sh-next-link" style="color:{ACCENT};"
+          href="https://docs.contextvm.org/spec/ceps/cep-6/" target="_blank" rel="noopener">
+          Server announcements →
+        </a>
+      </div>
+      <div class="sh-next-card">
+        <h5 class="sh-next-title">Add payments</h5>
+        <p class="sh-next-desc">Charge clients for using your server via the Lightning Network.</p>
+        <a class="sh-next-link" style="color:{ACCENT};"
+          href="https://docs.contextvm.org/ts-sdk/payments/overview/" target="_blank" rel="noopener">
+          Set up payments →
+        </a>
+      </div>
+    </div>
+
+  </div>
+</main>
+
+<style>
+  /* All classes prefixed sh- to avoid collision with any global site styles */
+
+  .sh-page {
+    max-width: 860px;
+    margin: 2rem auto;
+    padding: 0 1rem 4rem;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Arial, sans-serif;
+  }
+
+  .sh-hero   { text-align: center; padding: 3rem 1rem 2rem; }
+  .sh-badge  { display: inline-block; font-size: 12px; font-weight: 500; padding: 4px 14px; border-radius: 20px; margin-bottom: 1rem; }
+  .sh-h1     { font-size: 2rem; font-weight: 500; margin: 0 0 0.75rem; line-height: 1.3; }
+  .sh-lead   { font-size: 1rem; max-width: 500px; margin: 0 auto; line-height: 1.6; opacity: 0.7; }
+
+  .sh-content { }
+
+  .sh-label {
+    font-size: 11px; font-weight: 500; letter-spacing: 0.08em;
+    text-transform: uppercase; opacity: 0.5; margin-top: 2rem; margin-bottom: 1rem;
+  }
+
+  .sh-chooser { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; margin-bottom: 2rem; }
+  .sh-card {
+    background: transparent; border-style: solid; border-radius: 12px;
+    padding: 1.25rem; cursor: pointer; text-align: left; color: inherit;
+    font-family: inherit; transition: border-color 0.15s, border-width 0.15s;
+  }
+  .sh-icon       { font-size: 18px; margin-bottom: 10px; }
+  .sh-card-title { font-size: 15px; font-weight: 500; margin: 0 0 5px; }
+  .sh-card-desc  { font-size: 13px; opacity: 0.65; line-height: 1.5; margin: 0; }
+  .sh-tag        { display: inline-block; font-size: 11px; font-weight: 500; padding: 3px 10px; border-radius: 20px; margin-top: 10px; }
+
+  .sh-steps  { display: flex; flex-direction: column; }
+  .sh-step   { display: grid; grid-template-columns: 48px 1fr; }
+  .sh-step-line { display: flex; flex-direction: column; align-items: center; }
+  .sh-num {
+    width: 32px; height: 32px; border-radius: 50%;
+    display: flex; align-items: center; justify-content: center;
+    font-size: 13px; font-weight: 600; flex-shrink: 0;
+  }
+  .sh-connector { width: 1px; background: rgba(128,128,128,0.2); flex: 1; margin: 5px 0; min-height: 20px; }
+  .sh-step:last-child .sh-connector { display: none; }
+  .sh-body       { padding-bottom: 1.75rem; }
+  .sh-step-title { font-size: 15px; font-weight: 500; margin: 4px 0 5px; }
+  .sh-step-desc  { font-size: 14px; opacity: 0.65; line-height: 1.6; margin: 0 0 10px; }
+
+  .sh-code {
+    background: rgba(128,128,128,0.1); border: 0.5px solid rgba(128,128,128,0.2);
+    border-radius: 8px; padding: 10px 14px;
+    font-family: 'SFMono-Regular', 'Consolas', monospace; font-size: 13px;
+    display: flex; justify-content: space-between; align-items: center; gap: 12px; word-break: break-all;
+  }
+  .sh-pre { display: block; white-space: pre; overflow-x: auto; line-height: 1.6; }
+  .sh-copy {
+    font-size: 11px; opacity: 0.5; background: none;
+    border: 0.5px solid rgba(128,128,128,0.3); border-radius: 4px;
+    padding: 3px 10px; cursor: pointer; flex-shrink: 0; font-family: inherit; color: inherit;
+  }
+  .sh-copy:hover { opacity: 0.8; }
+
+  /* Tip — colours applied via inline style so they're never overridden */
+  .sh-tip {
+    border-left-style: solid; border-left-width: 3px;
+    border-radius: 0 8px 8px 0; padding: 10px 14px;
+    font-size: 13px; margin-top: 10px; line-height: 1.55;
+  }
+
+  .sh-prereq-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; margin-top: 10px; }
+  .sh-prereq {
+    background: rgba(128,128,128,0.1); border-radius: 8px;
+    padding: 10px 14px; font-size: 13px; opacity: 0.8;
+    display: flex; align-items: center; gap: 8px;
+  }
+  .sh-check { width: 18px; height: 18px; border-radius: 50%; display: flex; align-items: center; justify-content: center; flex-shrink: 0; }
+
+  .sh-divider { border: none; border-top: 0.5px solid rgba(128,128,128,0.2); margin: 2rem 0; }
+
+  .sh-next-grid { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 10px; }
+  .sh-next-card { background: rgba(128,128,128,0.08); border: 0.5px solid rgba(128,128,128,0.2); border-radius: 12px; padding: 1rem; }
+  .sh-next-title { font-size: 13px; font-weight: 500; margin: 0 0 5px; }
+  .sh-next-desc  { font-size: 12px; opacity: 0.6; line-height: 1.5; margin: 0; }
+  .sh-next-link  { font-size: 12px; margin-top: 8px; display: block; text-decoration: none; }
+  .sh-next-link:hover { text-decoration: underline; }
+
+  @media (max-width: 600px) {
+    .sh-chooser     { grid-template-columns: 1fr; }
+    .sh-next-grid   { grid-template-columns: 1fr; }
+    .sh-prereq-grid { grid-template-columns: 1fr; }
+    .sh-h1          { font-size: 1.5rem; }
+  }
+</style>

--- a/src/routes/self-host/+page.svelte
+++ b/src/routes/self-host/+page.svelte
@@ -1,175 +1,180 @@
 <script lang="ts">
-  import Seo from '$lib/components/SEO.svelte';
-
-  let activePath = $state<'cvmi' | 'ts'>('cvmi');
-
-  // Orange accent — matches contextvm.org "Read docs" button
-  const ACCENT       = '#E8550A';
-  const ACCENT_LIGHT = '#FDE9DF';
-  const ACCENT_DARK  = '#A33A05';
-
-  function copyCode(text: string, btn: HTMLButtonElement) {
-    navigator.clipboard.writeText(text).then(() => {
-      btn.textContent = 'copied';
-      setTimeout(() => (btn.textContent = 'copy'), 1500);
-    }).catch(() => {
-      btn.textContent = 'copy';
-    });
-  }
+	import Seo from '$lib/components/SEO.svelte';
+	import { Tabs, TabsList, TabsTrigger, TabsContent } from '$lib/components/ui/tabs';
+	import { copyToClipboard } from '$lib/utils';
 </script>
 
 <Seo
-  title="Self-Host a Server | ContextVM"
-  description="A complete guide to hosting a ContextVM server on the Nostr network. Choose your path — no-code CLI with CVMI or custom integration with the TypeScript SDK."
+	title="Self-Host a Server"
+	description="A complete guide to hosting a ContextVM server on the Nostr network. Choose your path — no-code CLI with CVMI or custom integration with the TypeScript SDK."
 />
 
-<main class="sh-page">
+<main class="min-h-screen bg-background px-4 py-8">
+	<div class="container mx-auto">
 
-  <!-- ── Hero ─────────────────────────────────────────────────────── -->
-  <div class="sh-hero">
-    <div class="sh-badge" style="background:{ACCENT_LIGHT}; color:{ACCENT_DARK};">
-      Self-hosting guide
-    </div>
-    <h1 class="sh-h1">Host your own ContextVM server</h1>
-    <p class="sh-lead">
-      Expose any MCP server to the decentralised Nostr network in minutes.
-      Pick your path below.
-    </p>
-  </div>
+		<!-- Hero -->
+		<div class="mx-auto mb-12 max-w-3xl text-center">
+			<span class="mb-4 inline-block rounded-full bg-primary/10 px-4 py-1 text-sm font-medium text-primary">
+				Self-hosting guide
+			</span>
+			<h1 class="mb-4 text-4xl font-bold tracking-tight sm:text-5xl">
+				Host your own ContextVM server
+			</h1>
+			<p class="text-lg text-muted-foreground">
+				Expose any MCP server to the decentralised Nostr network in minutes.
+				Pick your path below.
+			</p>
+		</div>
 
-  <!-- ── Content ───────────────────────────────────────────────────── -->
-  <div class="sh-content">
+		<!-- Path tabs -->
+		<div class="mx-auto max-w-3xl">
+			<Tabs value="cvmi">
+				<TabsList class="mb-8 w-full">
+					<TabsTrigger value="cvmi" class="flex-1">
+						⚡ CVMI — Quick Setup
+					</TabsTrigger>
+					<TabsTrigger value="ts" class="flex-1">
+						🛠 TypeScript SDK
+					</TabsTrigger>
+				</TabsList>
 
-    <div class="sh-label">Choose your approach</div>
+				<!-- ── CVMI PATH ──────────────────────────────────────────── -->
+				<TabsContent value="cvmi">
+					<p class="mb-8 text-muted-foreground">
+						The quickest way to get a server running. No code required — CVMI handles
+						keys, relays, and encryption for you with a single terminal command.
+					</p>
 
-    <!-- Path chooser -->
-    <div class="sh-chooser">
-      <button
-        class="sh-card"
-        style="border-color:{activePath === 'cvmi' ? ACCENT : 'rgba(128,128,128,0.25)'}; border-width:{activePath === 'cvmi' ? '2px' : '0.5px'};"
-        onclick={() => (activePath = 'cvmi')}
-      >
-        <div class="sh-icon">⚡</div>
-        <h3 class="sh-card-title">CVMI (CLI tool)</h3>
-        <p class="sh-card-desc">Quickest way to get a server running. No code required — just a terminal.</p>
-        <span class="sh-tag" style="background:{ACCENT_LIGHT}; color:{ACCENT_DARK};">Recommended for beginners</span>
-      </button>
+					<div class="space-y-8">
 
-      <button
-        class="sh-card"
-        style="border-color:{activePath === 'ts' ? ACCENT : 'rgba(128,128,128,0.25)'}; border-width:{activePath === 'ts' ? '2px' : '0.5px'};"
-        onclick={() => (activePath = 'ts')}
-      >
-        <div class="sh-icon">🛠</div>
-        <h3 class="sh-card-title">TypeScript SDK</h3>
-        <p class="sh-card-desc">Build a custom server with full control over transport, keys, and behaviour.</p>
-        <span class="sh-tag" style="background:#E6F1FB; color:#185FA5;">For developers</span>
-      </button>
-    </div>
+						<!-- Step 1 -->
+						<div class="flex gap-4">
+							<div class="flex flex-col items-center">
+								<div class="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-primary text-sm font-semibold text-primary-foreground">
+									1
+								</div>
+								<div class="mt-2 w-px flex-1 bg-border"></div>
+							</div>
+							<div class="pb-8">
+								<h3 class="mb-2 font-semibold">Check prerequisites</h3>
+								<p class="mb-4 text-sm text-muted-foreground">
+									You need Node.js 18 or higher installed. That's it — no global installs required.
+								</p>
+								<div class="grid grid-cols-2 gap-3">
+									<div class="flex items-center gap-2 rounded-lg bg-muted px-4 py-3 text-sm">
+										<span class="flex h-5 w-5 items-center justify-center rounded-full bg-primary text-[10px] text-primary-foreground">✓</span>
+										Node.js 18 or higher
+									</div>
+									<div class="flex items-center gap-2 rounded-lg bg-muted px-4 py-3 text-sm">
+										<span class="flex h-5 w-5 items-center justify-center rounded-full bg-primary text-[10px] text-primary-foreground">✓</span>
+										npm, yarn, pnpm, or bun
+									</div>
+								</div>
+								<blockquote class="mt-3">
+									Check your Node version: <code>node --version</code>
+								</blockquote>
+							</div>
+						</div>
 
-    <!-- ── CVMI PATH ─────────────────────────────────────────────── -->
-    {#if activePath === 'cvmi'}
-      <div class="sh-label">Step-by-step — CVMI path</div>
-      <div class="sh-steps">
+						<!-- Step 2 -->
+						<div class="flex gap-4">
+							<div class="flex flex-col items-center">
+								<div class="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-primary text-sm font-semibold text-primary-foreground">
+									2
+								</div>
+								<div class="mt-2 w-px flex-1 bg-border"></div>
+							</div>
+							<div class="pb-8">
+								<h3 class="mb-2 font-semibold">Verify CVMI works</h3>
+								<p class="mb-4 text-sm text-muted-foreground">
+									No installation needed. Run this once to confirm everything is set up correctly.
+								</p>
+								<div class="flex items-center justify-between rounded-lg bg-muted px-4 py-3">
+									<code class="text-sm">npx cvmi --help</code>
+									<button
+										onclick={() => copyToClipboard('npx cvmi --help')}
+										class="ml-4 shrink-0 rounded border border-border px-3 py-1 text-xs text-muted-foreground hover:text-foreground"
+									>
+										copy
+									</button>
+								</div>
+								<blockquote class="mt-3">
+									You should see a list of available commands. If you do, you're ready.
+								</blockquote>
+							</div>
+						</div>
 
-        <div class="sh-step">
-          <div class="sh-step-line">
-            <div class="sh-num" style="background:{ACCENT}; color:#fff;">1</div>
-            <div class="sh-connector"></div>
-          </div>
-          <div class="sh-body">
-            <h4 class="sh-step-title">Check prerequisites</h4>
-            <p class="sh-step-desc">You need Node.js 18 or higher installed. That's it — no global installs required.</p>
-            <div class="sh-prereq-grid">
-              <div class="sh-prereq">
-                <div class="sh-check" style="background:{ACCENT};">
-                  <svg viewBox="0 0 10 10" fill="none" width="10" height="10">
-                    <polyline points="2,5 4,7.5 8,3" stroke="white" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-                  </svg>
-                </div>
-                Node.js 18 or higher
-              </div>
-              <div class="sh-prereq">
-                <div class="sh-check" style="background:{ACCENT};">
-                  <svg viewBox="0 0 10 10" fill="none" width="10" height="10">
-                    <polyline points="2,5 4,7.5 8,3" stroke="white" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-                  </svg>
-                </div>
-                npm, yarn, pnpm, or bun
-              </div>
-            </div>
-            <div class="sh-tip" style="background:{ACCENT_LIGHT}; border-left-color:{ACCENT}; color:{ACCENT_DARK};">
-              Check your Node version: <code style="color:{ACCENT_DARK}; font-family:monospace;">node --version</code>
-            </div>
-          </div>
-        </div>
+						<!-- Step 3 -->
+						<div class="flex gap-4">
+							<div class="flex flex-col items-center">
+								<div class="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-primary text-sm font-semibold text-primary-foreground">
+									3
+								</div>
+								<div class="mt-2 w-px flex-1 bg-border"></div>
+							</div>
+							<div class="pb-8">
+								<h3 class="mb-2 font-semibold">Start your server</h3>
+								<p class="mb-4 text-sm text-muted-foreground">
+									This exposes a local filesystem MCP server to the Nostr network.
+									A cryptographic key pair is auto-generated for you.
+								</p>
+								<div class="flex items-center justify-between rounded-lg bg-muted px-4 py-3">
+									<code class="break-all text-sm">npx cvmi serve -- npx -y @modelcontextprotocol/server-filesystem /tmp</code>
+									<button
+										onclick={() => copyToClipboard('npx cvmi serve -- npx -y @modelcontextprotocol/server-filesystem /tmp')}
+										class="ml-4 shrink-0 rounded border border-border px-3 py-1 text-xs text-muted-foreground hover:text-foreground"
+									>
+										copy
+									</button>
+								</div>
+								<blockquote class="mt-3">
+									Your server's public key (<code>npub1...</code>) will print in the terminal.
+									Save it — you'll need it to connect clients.
+								</blockquote>
+							</div>
+						</div>
 
-        <div class="sh-step">
-          <div class="sh-step-line">
-            <div class="sh-num" style="background:{ACCENT}; color:#fff;">2</div>
-            <div class="sh-connector"></div>
-          </div>
-          <div class="sh-body">
-            <h4 class="sh-step-title">Verify CVMI works</h4>
-            <p class="sh-step-desc">No installation needed. Run this once to confirm everything is set up correctly.</p>
-            <div class="sh-code">
-              <span>npx cvmi --help</span>
-              <button class="sh-copy" onclick={(e) => copyCode('npx cvmi --help', e.currentTarget)}>copy</button>
-            </div>
-            <div class="sh-tip" style="background:{ACCENT_LIGHT}; border-left-color:{ACCENT}; color:{ACCENT_DARK};">
-              You should see a list of available commands. If you do, you're ready.
-            </div>
-          </div>
-        </div>
+						<!-- Step 4 -->
+						<div class="flex gap-4">
+							<div class="flex flex-col items-center">
+								<div class="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-primary text-sm font-semibold text-primary-foreground">
+									4
+								</div>
+								<div class="mt-2 w-px flex-1 bg-border"></div>
+							</div>
+							<div class="pb-8">
+								<h3 class="mb-2 font-semibold">Connect a client</h3>
+								<p class="mb-4 text-sm text-muted-foreground">
+									From any machine with CVMI installed, connect to your server using its public key.
+									This creates a local stdio proxy that bridges your Nostr-hosted server to any
+									standard MCP client.
+								</p>
+								<div class="flex items-center justify-between rounded-lg bg-muted px-4 py-3">
+									<code class="text-sm">npx cvmi use npub1q...</code>
+									<button
+										onclick={() => copyToClipboard('npx cvmi use npub1q...')}
+										class="ml-4 shrink-0 rounded border border-border px-3 py-1 text-xs text-muted-foreground hover:text-foreground"
+									>
+										copy
+									</button>
+								</div>
+							</div>
+						</div>
 
-        <div class="sh-step">
-          <div class="sh-step-line">
-            <div class="sh-num" style="background:{ACCENT}; color:#fff;">3</div>
-            <div class="sh-connector"></div>
-          </div>
-          <div class="sh-body">
-            <h4 class="sh-step-title">Start your server</h4>
-            <p class="sh-step-desc">
-              This exposes a local filesystem MCP server to the Nostr network.
-              A cryptographic key pair is auto-generated for you.
-            </p>
-            <div class="sh-code">
-              <span>npx cvmi serve -- npx -y @modelcontextprotocol/server-filesystem /tmp</span>
-              <button class="sh-copy" onclick={(e) => copyCode('npx cvmi serve -- npx -y @modelcontextprotocol/server-filesystem /tmp', e.currentTarget)}>copy</button>
-            </div>
-            <div class="sh-tip" style="background:{ACCENT_LIGHT}; border-left-color:{ACCENT}; color:{ACCENT_DARK};">
-              Your server's public key (<code style="color:{ACCENT_DARK}; font-family:monospace;">npub1...</code>) will print in the terminal. Save it — you'll need it to connect clients.
-            </div>
-          </div>
-        </div>
-
-        <div class="sh-step">
-          <div class="sh-step-line">
-            <div class="sh-num" style="background:{ACCENT}; color:#fff;">4</div>
-            <div class="sh-connector"></div>
-          </div>
-          <div class="sh-body">
-            <h4 class="sh-step-title">Connect a client</h4>
-            <p class="sh-step-desc">From another machine or MCP client, connect using your server's public key.</p>
-            <div class="sh-code">
-              <span>npx cvmi use npub1q...</span>
-              <button class="sh-copy" onclick={(e) => copyCode('npx cvmi use npub1q...', e.currentTarget)}>copy</button>
-            </div>
-          </div>
-        </div>
-
-        <div class="sh-step">
-          <div class="sh-step-line">
-            <div class="sh-num" style="background:{ACCENT}; color:#fff;">5</div>
-            <div class="sh-connector"></div>
-          </div>
-          <div class="sh-body">
-            <h4 class="sh-step-title">Optional: configure your server</h4>
-            <p class="sh-step-desc">
-              Create a <code style="font-family:monospace;">.cvmi.json</code> in your project folder to set relays,
-              encryption, and a persistent private key.
-            </p>
-            <pre class="sh-code sh-pre">{`{
+						<!-- Step 5 -->
+						<div class="flex gap-4">
+							<div class="flex flex-col items-center">
+								<div class="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-primary text-sm font-semibold text-primary-foreground">
+									5
+								</div>
+							</div>
+							<div class="pb-2">
+								<h3 class="mb-2 font-semibold">Optional: configure your server</h3>
+								<p class="mb-4 text-sm text-muted-foreground">
+									Create a <code>.cvmi.json</code> in your project folder to use a persistent
+									private key, specific relays, or required encryption.
+								</p>
+								<pre>{`{
   "serve": {
     "privateKey": "nsec1...",
     "relays": ["wss://relay.damus.io"],
@@ -177,257 +182,237 @@
     "public": true
   }
 }`}</pre>
-            <div class="sh-tip" style="background:{ACCENT_LIGHT}; border-left-color:{ACCENT}; color:{ACCENT_DARK};">
-              Full reference:
-              <a href="https://docs.contextvm.org/cvmi/configuration/" target="_blank" rel="noopener"
-                style="color:{ACCENT_DARK}; font-weight:600;">
-                docs.contextvm.org/cvmi/configuration
-              </a>
-            </div>
-          </div>
-        </div>
+								<blockquote class="mt-3">
+									Full reference:
+									<a href="https://docs.contextvm.org/cvmi/configuration/" target="_blank" rel="noopener">
+										docs.contextvm.org/cvmi/configuration
+									</a>
+								</blockquote>
+							</div>
+						</div>
 
-      </div>
-    {/if}
+					</div>
+				</TabsContent>
 
-    <!-- ── TYPESCRIPT SDK PATH ───────────────────────────────────── -->
-    {#if activePath === 'ts'}
-      <div class="sh-label">Step-by-step — TypeScript SDK path</div>
-      <div class="sh-steps">
+				<!-- ── TYPESCRIPT SDK PATH ────────────────────────────────── -->
+				<TabsContent value="ts">
+					<p class="mb-8 text-muted-foreground">
+						For building custom servers or embedding ContextVM directly into your application.
+						The SDK gives you full control over transport, signing, and relay management.
+					</p>
 
-        <div class="sh-step">
-          <div class="sh-step-line">
-            <div class="sh-num" style="background:{ACCENT}; color:#fff;">1</div>
-            <div class="sh-connector"></div>
-          </div>
-          <div class="sh-body">
-            <h4 class="sh-step-title">Install the SDK</h4>
-            <p class="sh-step-desc">Add the ContextVM TypeScript SDK to your project.</p>
-            <div class="sh-code">
-              <span>npm install @contextvm/sdk</span>
-              <button class="sh-copy" onclick={(e) => copyCode('npm install @contextvm/sdk', e.currentTarget)}>copy</button>
-            </div>
-          </div>
-        </div>
+					<div class="space-y-8">
 
-        <div class="sh-step">
-          <div class="sh-step-line">
-            <div class="sh-num" style="background:{ACCENT}; color:#fff;">2</div>
-            <div class="sh-connector"></div>
-          </div>
-          <div class="sh-body">
-            <h4 class="sh-step-title">Understand the core building blocks</h4>
-            <p class="sh-step-desc">
-              Before writing code, get familiar with the three concepts that power every
-              ContextVM integration: <strong>transports</strong>, <strong>signers</strong>,
-              and <strong>relay handlers</strong>.
-            </p>
-            <div class="sh-tip" style="background:{ACCENT_LIGHT}; border-left-color:{ACCENT}; color:{ACCENT_DARK};">
-              Start with the
-              <a href="https://docs.contextvm.org/ts-sdk/quick-overview/" target="_blank" rel="noopener"
-                style="color:{ACCENT_DARK}; font-weight:600;">SDK Quick Overview</a>
-              — it maps out what each module does and how they fit together.
-            </div>
-          </div>
-        </div>
+						<!-- Step 1 -->
+						<div class="flex gap-4">
+							<div class="flex flex-col items-center">
+								<div class="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-primary text-sm font-semibold text-primary-foreground">
+									1
+								</div>
+								<div class="mt-2 w-px flex-1 bg-border"></div>
+							</div>
+							<div class="pb-8">
+								<h3 class="mb-2 font-semibold">Install the SDK</h3>
+								<p class="mb-4 text-sm text-muted-foreground">
+									Add the ContextVM TypeScript SDK to your project.
+								</p>
+								<div class="flex items-center justify-between rounded-lg bg-muted px-4 py-3">
+									<code class="text-sm">npm install @contextvm/sdk</code>
+									<button
+										onclick={() => copyToClipboard('npm install @contextvm/sdk')}
+										class="ml-4 shrink-0 rounded border border-border px-3 py-1 text-xs text-muted-foreground hover:text-foreground"
+									>
+										copy
+									</button>
+								</div>
+							</div>
+						</div>
 
-        <div class="sh-step">
-          <div class="sh-step-line">
-            <div class="sh-num" style="background:{ACCENT}; color:#fff;">3</div>
-            <div class="sh-connector"></div>
-          </div>
-          <div class="sh-body">
-            <h4 class="sh-step-title">Choose the right component for hosting</h4>
-            <p class="sh-step-desc">Two components handle the server side:</p>
-            <div class="sh-prereq-grid">
-              <div class="sh-prereq" style="flex-direction:column; align-items:flex-start; gap:4px;">
-                <strong style="font-size:13px;">NostrMCPGateway</strong>
-                <span>Exposes an existing MCP server to the Nostr network</span>
-              </div>
-              <div class="sh-prereq" style="flex-direction:column; align-items:flex-start; gap:4px;">
-                <strong style="font-size:13px;">NostrMCPProxy</strong>
-                <span>Bridges a Nostr server to a local stdio MCP client</span>
-              </div>
-            </div>
-            <div class="sh-tip" style="background:{ACCENT_LIGHT}; border-left-color:{ACCENT}; color:{ACCENT_DARK};">
-              See
-              <a href="https://docs.contextvm.org/ts-sdk/gateway/overview/" target="_blank" rel="noopener"
-                style="color:{ACCENT_DARK}; font-weight:600;">Gateway docs</a>
-              and
-              <a href="https://docs.contextvm.org/ts-sdk/proxy/overview/" target="_blank" rel="noopener"
-                style="color:{ACCENT_DARK}; font-weight:600;">Proxy docs</a>
-              for implementation details.
-            </div>
-          </div>
-        </div>
+						<!-- Step 2 -->
+						<div class="flex gap-4">
+							<div class="flex flex-col items-center">
+								<div class="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-primary text-sm font-semibold text-primary-foreground">
+									2
+								</div>
+								<div class="mt-2 w-px flex-1 bg-border"></div>
+							</div>
+							<div class="pb-8">
+								<h3 class="mb-2 font-semibold">Understand the core building blocks</h3>
+								<p class="mb-4 text-sm text-muted-foreground">
+									Before writing code, get familiar with the three concepts every ContextVM
+									integration is built on: <strong>transports</strong>, <strong>signers</strong>,
+									and <strong>relay handlers</strong>.
+								</p>
+								<blockquote>
+									Start with the
+									<a href="https://docs.contextvm.org/ts-sdk/quick-overview/" target="_blank" rel="noopener">
+										SDK Quick Overview
+									</a>
+									— it maps out what each module does and how they fit together.
+								</blockquote>
+							</div>
+						</div>
 
-        <div class="sh-step">
-          <div class="sh-step-line">
-            <div class="sh-num" style="background:{ACCENT}; color:#fff;">4</div>
-            <div class="sh-connector"></div>
-          </div>
-          <div class="sh-body">
-            <h4 class="sh-step-title">Run the client-server tutorial</h4>
-            <p class="sh-step-desc">
-              Work through the hands-on example to see a full server and client
-              interaction in TypeScript before writing your own.
-            </p>
-            <div class="sh-tip" style="background:{ACCENT_LIGHT}; border-left-color:{ACCENT}; color:{ACCENT_DARK};">
-              Found under Tutorials →
-              <a href="https://docs.contextvm.org/ts-sdk/tutorials/client-server-communication/"
-                target="_blank" rel="noopener"
-                style="color:{ACCENT_DARK}; font-weight:600;">Client-Server Communication</a>
-              in the docs sidebar.
-            </div>
-          </div>
-        </div>
+						<!-- Step 3 -->
+						<div class="flex gap-4">
+							<div class="flex flex-col items-center">
+								<div class="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-primary text-sm font-semibold text-primary-foreground">
+									3
+								</div>
+								<div class="mt-2 w-px flex-1 bg-border"></div>
+							</div>
+							<div class="pb-8">
+								<h3 class="mb-2 font-semibold">Choose the right transport for your use case</h3>
+								<p class="mb-4 text-sm text-muted-foreground">
+									The SDK provides two Nostr transports for hosting:
+								</p>
+								<div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
+									<div class="rounded-lg border border-border bg-card p-4">
+										<p class="mb-1 font-medium text-card-foreground">NostrServerTransport</p>
+										<p class="text-sm text-muted-foreground">
+											Used by MCP servers to expose their capabilities through Nostr.
+											Use this when building a custom server from scratch.
+										</p>
+										<a
+											href="https://docs.contextvm.org/ts-sdk/transports/nostr-server-transport/"
+											target="_blank"
+											rel="noopener"
+											class="mt-2 block text-sm text-primary hover:underline"
+										>
+											Server transport docs →
+										</a>
+									</div>
+									<div class="rounded-lg border border-border bg-card p-4">
+										<p class="mb-1 font-medium text-card-foreground">NostrClientTransport</p>
+										<p class="text-sm text-muted-foreground">
+											Used by MCP clients to connect to remote servers exposed via Nostr.
+											Use this when building a custom client.
+										</p>
+										<a
+											href="https://docs.contextvm.org/ts-sdk/transports/nostr-client-transport/"
+											target="_blank"
+											rel="noopener"
+											class="mt-2 block text-sm text-primary hover:underline"
+										>
+											Client transport docs →
+										</a>
+									</div>
+								</div>
+								<blockquote class="mt-4">
+									If you want to expose an <strong>already-existing</strong> MCP server to Nostr
+									without rewriting it, use
+									<a href="https://docs.contextvm.org/ts-sdk/gateway/overview/" target="_blank" rel="noopener">NostrMCPGateway</a>
+									instead. To consume a CVM server in a standard MCP host, use
+									<a href="https://docs.contextvm.org/ts-sdk/proxy/overview/" target="_blank" rel="noopener">NostrMCPProxy</a>.
+								</blockquote>
+							</div>
+						</div>
 
-        <div class="sh-step">
-          <div class="sh-step-line">
-            <div class="sh-num" style="background:{ACCENT}; color:#fff;">5</div>
-            <div class="sh-connector"></div>
-          </div>
-          <div class="sh-body">
-            <h4 class="sh-step-title">Go live</h4>
-            <p class="sh-step-desc">
-              Once built, your server needs a Nostr private key and relay configuration
-              to go live on the network. Pass keys and relays directly into the SDK's
-              transport options.
-            </p>
-            <div class="sh-tip" style="background:{ACCENT_LIGHT}; border-left-color:{ACCENT}; color:{ACCENT_DARK};">
-              Want to charge clients for access? Set up
-              <a href="https://docs.contextvm.org/ts-sdk/payments/overview/" target="_blank" rel="noopener"
-                style="color:{ACCENT_DARK}; font-weight:600;">Lightning payments via CEP-8</a>.
-            </div>
-          </div>
-        </div>
+						<!-- Step 4 -->
+						<div class="flex gap-4">
+							<div class="flex flex-col items-center">
+								<div class="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-primary text-sm font-semibold text-primary-foreground">
+									4
+								</div>
+								<div class="mt-2 w-px flex-1 bg-border"></div>
+							</div>
+							<div class="pb-8">
+								<h3 class="mb-2 font-semibold">Follow the client-server tutorial</h3>
+								<p class="mb-4 text-sm text-muted-foreground">
+									Work through the hands-on example to see a full server and client interaction
+									in TypeScript before writing your own.
+								</p>
+								<blockquote>
+									Found under Tutorials →
+									<a
+										href="https://docs.contextvm.org/ts-sdk/tutorials/client-server-communication/"
+										target="_blank"
+										rel="noopener"
+									>
+										Client-Server Communication
+									</a>
+									in the docs sidebar.
+								</blockquote>
+							</div>
+						</div>
 
-      </div>
-    {/if}
+						<!-- Step 5 -->
+						<div class="flex gap-4">
+							<div class="flex flex-col items-center">
+								<div class="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-primary text-sm font-semibold text-primary-foreground">
+									5
+								</div>
+							</div>
+							<div class="pb-2">
+								<h3 class="mb-2 font-semibold">Go live</h3>
+								<p class="mb-4 text-sm text-muted-foreground">
+									Once built, configure your server with a Nostr private key and relay list
+									and pass them into your transport options to go live on the network.
+								</p>
+								<blockquote>
+									Want to charge clients for access? Set up
+									<a href="https://docs.contextvm.org/ts-sdk/payments/overview/" target="_blank" rel="noopener">
+										Lightning payments via CEP-8
+									</a>.
+								</blockquote>
+							</div>
+						</div>
 
-    <hr class="sh-divider" />
+					</div>
+				</TabsContent>
+			</Tabs>
 
-    <!-- What's next -->
-    <div class="sh-label">What's next</div>
-    <div class="sh-next-grid">
-      <div class="sh-next-card">
-        <h5 class="sh-next-title">Add skills</h5>
-        <p class="sh-next-desc">Install reference implementations and templates to accelerate development.</p>
-        <a class="sh-next-link" style="color:{ACCENT};"
-          href="https://docs.contextvm.org/cvmi/skills/overview/" target="_blank" rel="noopener">
-          Learn about skills →
-        </a>
-      </div>
-      <div class="sh-next-card">
-        <h5 class="sh-next-title">Publish your server</h5>
-        <p class="sh-next-desc">Make your server publicly discoverable on the Nostr network.</p>
-        <a class="sh-next-link" style="color:{ACCENT};"
-          href="https://docs.contextvm.org/spec/ceps/cep-6/" target="_blank" rel="noopener">
-          Server announcements →
-        </a>
-      </div>
-      <div class="sh-next-card">
-        <h5 class="sh-next-title">Add payments</h5>
-        <p class="sh-next-desc">Charge clients for using your server via the Lightning Network.</p>
-        <a class="sh-next-link" style="color:{ACCENT};"
-          href="https://docs.contextvm.org/ts-sdk/payments/overview/" target="_blank" rel="noopener">
-          Set up payments →
-        </a>
-      </div>
-    </div>
+			<!-- What's next -->
+			<div class="mt-12 border-t border-border pt-10">
+				<p class="mb-6 text-sm font-medium uppercase tracking-widest text-muted-foreground">
+					What's next
+				</p>
+				<div class="grid grid-cols-1 gap-4 sm:grid-cols-3">
+					<div class="rounded-lg border border-border bg-card p-4">
+						<h4 class="mb-2 font-semibold text-card-foreground">Add skills</h4>
+						<p class="mb-3 text-sm text-muted-foreground">
+							Install reference implementations and templates to accelerate development.
+						</p>
+						<a
+							href="https://docs.contextvm.org/cvmi/skills/overview/"
+							target="_blank"
+							rel="noopener"
+							class="text-sm text-primary hover:underline"
+						>
+							Learn about skills →
+						</a>
+					</div>
+					<div class="rounded-lg border border-border bg-card p-4">
+						<h4 class="mb-2 font-semibold text-card-foreground">Publish your server</h4>
+						<p class="mb-3 text-sm text-muted-foreground">
+							Make your server publicly discoverable on the Nostr network.
+						</p>
+						<a
+							href="https://docs.contextvm.org/spec/ceps/cep-6/"
+							target="_blank"
+							rel="noopener"
+							class="text-sm text-primary hover:underline"
+						>
+							Server announcements →
+						</a>
+					</div>
+					<div class="rounded-lg border border-border bg-card p-4">
+						<h4 class="mb-2 font-semibold text-card-foreground">Add payments</h4>
+						<p class="mb-3 text-sm text-muted-foreground">
+							Charge clients for using your server via the Lightning Network.
+						</p>
+						<a
+							href="https://docs.contextvm.org/ts-sdk/payments/overview/"
+							target="_blank"
+							rel="noopener"
+							class="text-sm text-primary hover:underline"
+						>
+							Set up payments →
+						</a>
+					</div>
+				</div>
+			</div>
 
-  </div>
+		</div>
+	</div>
 </main>
-
-<style>
-  /* All classes prefixed sh- to avoid collision with any global site styles */
-
-  .sh-page {
-    max-width: 860px;
-    margin: 2rem auto;
-    padding: 0 1rem 4rem;
-    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Arial, sans-serif;
-  }
-
-  .sh-hero   { text-align: center; padding: 3rem 1rem 2rem; }
-  .sh-badge  { display: inline-block; font-size: 12px; font-weight: 500; padding: 4px 14px; border-radius: 20px; margin-bottom: 1rem; }
-  .sh-h1     { font-size: 2rem; font-weight: 500; margin: 0 0 0.75rem; line-height: 1.3; }
-  .sh-lead   { font-size: 1rem; max-width: 500px; margin: 0 auto; line-height: 1.6; opacity: 0.7; }
-
-  .sh-content { }
-
-  .sh-label {
-    font-size: 11px; font-weight: 500; letter-spacing: 0.08em;
-    text-transform: uppercase; opacity: 0.5; margin-top: 2rem; margin-bottom: 1rem;
-  }
-
-  .sh-chooser { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; margin-bottom: 2rem; }
-  .sh-card {
-    background: transparent; border-style: solid; border-radius: 12px;
-    padding: 1.25rem; cursor: pointer; text-align: left; color: inherit;
-    font-family: inherit; transition: border-color 0.15s, border-width 0.15s;
-  }
-  .sh-icon       { font-size: 18px; margin-bottom: 10px; }
-  .sh-card-title { font-size: 15px; font-weight: 500; margin: 0 0 5px; }
-  .sh-card-desc  { font-size: 13px; opacity: 0.65; line-height: 1.5; margin: 0; }
-  .sh-tag        { display: inline-block; font-size: 11px; font-weight: 500; padding: 3px 10px; border-radius: 20px; margin-top: 10px; }
-
-  .sh-steps  { display: flex; flex-direction: column; }
-  .sh-step   { display: grid; grid-template-columns: 48px 1fr; }
-  .sh-step-line { display: flex; flex-direction: column; align-items: center; }
-  .sh-num {
-    width: 32px; height: 32px; border-radius: 50%;
-    display: flex; align-items: center; justify-content: center;
-    font-size: 13px; font-weight: 600; flex-shrink: 0;
-  }
-  .sh-connector { width: 1px; background: rgba(128,128,128,0.2); flex: 1; margin: 5px 0; min-height: 20px; }
-  .sh-step:last-child .sh-connector { display: none; }
-  .sh-body       { padding-bottom: 1.75rem; }
-  .sh-step-title { font-size: 15px; font-weight: 500; margin: 4px 0 5px; }
-  .sh-step-desc  { font-size: 14px; opacity: 0.65; line-height: 1.6; margin: 0 0 10px; }
-
-  .sh-code {
-    background: rgba(128,128,128,0.1); border: 0.5px solid rgba(128,128,128,0.2);
-    border-radius: 8px; padding: 10px 14px;
-    font-family: 'SFMono-Regular', 'Consolas', monospace; font-size: 13px;
-    display: flex; justify-content: space-between; align-items: center; gap: 12px; word-break: break-all;
-  }
-  .sh-pre { display: block; white-space: pre; overflow-x: auto; line-height: 1.6; }
-  .sh-copy {
-    font-size: 11px; opacity: 0.5; background: none;
-    border: 0.5px solid rgba(128,128,128,0.3); border-radius: 4px;
-    padding: 3px 10px; cursor: pointer; flex-shrink: 0; font-family: inherit; color: inherit;
-  }
-  .sh-copy:hover { opacity: 0.8; }
-
-  /* Tip — colours applied via inline style so they're never overridden */
-  .sh-tip {
-    border-left-style: solid; border-left-width: 3px;
-    border-radius: 0 8px 8px 0; padding: 10px 14px;
-    font-size: 13px; margin-top: 10px; line-height: 1.55;
-  }
-
-  .sh-prereq-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; margin-top: 10px; }
-  .sh-prereq {
-    background: rgba(128,128,128,0.1); border-radius: 8px;
-    padding: 10px 14px; font-size: 13px; opacity: 0.8;
-    display: flex; align-items: center; gap: 8px;
-  }
-  .sh-check { width: 18px; height: 18px; border-radius: 50%; display: flex; align-items: center; justify-content: center; flex-shrink: 0; }
-
-  .sh-divider { border: none; border-top: 0.5px solid rgba(128,128,128,0.2); margin: 2rem 0; }
-
-  .sh-next-grid { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 10px; }
-  .sh-next-card { background: rgba(128,128,128,0.08); border: 0.5px solid rgba(128,128,128,0.2); border-radius: 12px; padding: 1rem; }
-  .sh-next-title { font-size: 13px; font-weight: 500; margin: 0 0 5px; }
-  .sh-next-desc  { font-size: 12px; opacity: 0.6; line-height: 1.5; margin: 0; }
-  .sh-next-link  { font-size: 12px; margin-top: 8px; display: block; text-decoration: none; }
-  .sh-next-link:hover { text-decoration: underline; }
-
-  @media (max-width: 600px) {
-    .sh-chooser     { grid-template-columns: 1fr; }
-    .sh-next-grid   { grid-template-columns: 1fr; }
-    .sh-prereq-grid { grid-template-columns: 1fr; }
-    .sh-h1          { font-size: 1.5rem; }
-  }
-</style>


### PR DESCRIPTION
## Summary

This PR adds a new `Self-Host a Server` documentation page as the primary entry point for anyone who wants to host on ContextVM. It was discussed in issues #10 and #11 and agreed upon with the maintainers.

Currently, there are two hosting paths — CVMI (no-code CLI) and the TypeScript SDK (custom integrations) — but no single page that acknowledges both exist, explains the difference, or guides a new user toward the right one. This page fills that gap.

## What this PR adds

**New page: `/self-hosting` (or `/getting-started/self-host`)**

The page is structured in three parts:

### 1. Path chooser (top of page)

A two-option section presented before any technical content, so the visitor makes one decision and follows one track:

| Option | Who it's for |
|---|---|
| **Quick Setup with CVMI** | No code required. Run any MCP server on Nostr with a single `npx` command |
| **Custom Integration with the TypeScript SDK** | Building an app or custom server? Implement ContextVM directly in your codebase |

### 2. CVMI path — end-to-end walkthrough

A single linear guide that consolidates what is currently split across `/cvmi/overview`, `/cvmi/installation`, `/cvmi/commands`, and `/cvmi/configuration`. The existing pages remain intact as detailed reference 
material — this guide is the beginner entry point that links out to them for deeper reading.

Steps covered:
1. Check Node.js version (18+ required)
2. Verify CVMI with `npx cvmi --help`
3. Start your server with `cvmi serve`
4. Note your public key (`npub1...`)
5. Connect a client with `cvmi use <pubkey>`
6. Optional: configure relays, encryption, and persistent keys via `.cvmi.json`

### 3. TypeScript SDK path — hosted server quickstart

A short section pointing to the SDK Quick Overview with a framing specifically for the hosting use case — `NostrMCPGateway` for exposing an existing server, `NostrMCPProxy` for connecting clients — so SDK users land in the right place without having to read the full module list to figure out what applies to them.

## What this PR does NOT change

- No existing pages are removed or restructured
- No content is duplicated — the new page summarises and links, it doesn't copy
- The four CVMI reference pages remain as-is

## Related changes recommended (outside this PR)

- Add `Self-Host a Server` to the Getting Started sidebar above the Specification section
- Link to this page from the homepage "Explore CVMI" button once that is implemented
- Add a nav bar entry pointing here alongside Docs and Servers

## How to review

The page is self-contained. Read it as a brand new user who has just landed on the site and wants to run a server — the goal is to get from zero to a running server without opening any other page first.

## Closes

Resolves #10 and Resolves #11 — Homepage CTAs don't surface self-hosting as an entry point and Getting Started page presents two hosting paths (CVMI vs TypeScript SDK) without helping users choose