### PR TITLE
feat:improve login flow with private key visibility, optional name field & profile fallback

### DIFF
--- a/src/lib/components/AccountLoginDialog.svelte
+++ b/src/lib/components/AccountLoginDialog.svelte
@@ -3,6 +3,7 @@
 	import * as Dialog from '$lib/components/ui/dialog/index.js';
 	import { Input } from '$lib/components/ui/input/index.js';
 	import { Label } from '$lib/components/ui/label/index.js';
+	import { Textarea } from '$lib/components/ui/textarea/index.js';
 	import { manager } from '$lib/services/accountManager.svelte';
 	import { ExtensionSigner, NostrConnectSigner } from 'applesauce-signers/signers';
 	import {
@@ -15,6 +16,7 @@
 	import { bytesToHex, hexToBytes } from 'nostr-tools/utils';
 	import { nsecEncode } from 'nostr-tools/nip19';
 	import { Metadata } from 'nostr-tools/kinds';
+	import type { ProfileContent } from 'applesauce-core/helpers';
 	import { DIALOG_IDS, dialogState } from '$lib/stores/dialog-state.svelte';
 	import { relayPool, metadataRelays } from '$lib/services/relay-pool';
 	import { copyToClipboard } from '$lib/utils';
@@ -35,8 +37,10 @@
 	let selectedTab = $state<'extension' | 'simple' | 'remote'>('extension');
 	let privateKey = $state('');
 	let showPrivateKey = $state(false);
-	let nickname = $state('');
-	let nameExpanded = $state(false);
+	let username = $state('');
+	let displayName = $state('');
+	let about = $state('');
+	let optionalExpanded = $state(false);
 	let bunkerUri = $state('');
 	let nostrConnectUri = $state('');
 	let loading = $state(false);
@@ -67,8 +71,10 @@
 	function resetSimpleState() {
 		privateKey = '';
 		showPrivateKey = false;
-		nickname = '';
-		nameExpanded = false;
+		username = '';
+		displayName = '';
+		about = '';
+		optionalExpanded = false;
 	}
 
 	async function connectSimple() {
@@ -84,13 +90,18 @@
 			const signer = PrivateKeyAccount.fromKey(privateKey.trim());
 			const account = new PrivateKeyAccount(signer.pubkey, signer.signer);
 
-			if (nickname.trim()) {
+			const content: ProfileContent = {};
+			if (username.trim()) content.name = username.trim();
+			if (displayName.trim()) content.display_name = displayName.trim();
+			if (about.trim()) content.about = about.trim();
+
+			if (Object.keys(content).length > 0) {
 				const event = finalizeEvent(
 					{
 						kind: Metadata,
 						created_at: Math.floor(Date.now() / 1000),
 						tags: [],
-						content: JSON.stringify({ name: nickname.trim() })
+						content: JSON.stringify(content)
 					},
 					account.signer.key
 				);
@@ -317,7 +328,9 @@
 									class="flex-1 font-mono"
 									type="text"
 								/>
-								<Button variant="outline" onclick={generatePrivateKey} type="button">Generate</Button>
+								<Button variant="outline" onclick={generatePrivateKey} type="button"
+									>Generate</Button
+								>
 							</div>
 						{:else}
 							<div class="flex gap-2">
@@ -358,23 +371,39 @@
 						</p>
 					</div>
 
-					<!-- Optional name accordion -->
-					<div class="space-y-2">
+					<!-- Profile Details Optional fields accordion -->
+					<div class="space-y-3">
 						<button
 							type="button"
-							onclick={() => (nameExpanded = !nameExpanded)}
+							onclick={() => (optionalExpanded = !optionalExpanded)}
 							class="flex items-center gap-1 text-sm font-medium"
 						>
-							Set a name
-							<span class="text-muted-foreground">(Optional)</span>
+							Profile Details (Optional)
 							<ChevronDown
-								class="ml-1 h-4 w-4 text-muted-foreground transition-transform duration-200 {nameExpanded
+								class="ml-1 h-4 w-4 text-muted-foreground transition-transform duration-200 {optionalExpanded
 									? 'rotate-180'
 									: ''}"
 							/>
 						</button>
-						{#if nameExpanded}
-							<Input placeholder="Enter your name" bind:value={nickname} />
+						{#if optionalExpanded}
+							<div class="space-y-3">
+								<div class="space-y-2">
+									<Label for="username">Username</Label>
+									<Input id="username" placeholder="Enter your username" bind:value={username} />
+								</div>
+								<div class="space-y-2">
+									<Label for="display-name">Display Name</Label>
+									<Input
+										id="display-name"
+										placeholder="Enter your display name"
+										bind:value={displayName}
+									/>
+								</div>
+								<div class="space-y-2">
+									<Label for="about">About</Label>
+									<Textarea id="about" placeholder="Tell others about you" bind:value={about} />
+								</div>
+							</div>
 						{/if}
 					</div>
 				</div>

--- a/src/lib/components/AccountLoginDialog.svelte
+++ b/src/lib/components/AccountLoginDialog.svelte
@@ -6,14 +6,23 @@
 	import { manager } from '$lib/services/accountManager.svelte';
 	import { ExtensionSigner, NostrConnectSigner } from 'applesauce-signers/signers';
 	import {
-		SimpleAccount,
+		PrivateKeyAccount,
 		ExtensionAccount,
 		NostrConnectAccount
 	} from 'applesauce-accounts/accounts';
 	import QrCode from '$lib/components/QrCode.svelte';
-	import { generateSecretKey } from 'nostr-tools';
-	import { bytesToHex } from 'nostr-tools/utils';
+	import { generateSecretKey, finalizeEvent } from 'nostr-tools';
+	import { bytesToHex, hexToBytes } from 'nostr-tools/utils';
+	import { nsecEncode } from 'nostr-tools/nip19';
+	import { Metadata } from 'nostr-tools/kinds';
 	import { DIALOG_IDS, dialogState } from '$lib/stores/dialog-state.svelte';
+	import { relayPool, metadataRelays } from '$lib/services/relay-pool';
+	import { copyToClipboard } from '$lib/utils';
+	import { toast } from 'svelte-sonner';
+	import Eye from '@lucide/svelte/icons/eye';
+	import EyeOff from '@lucide/svelte/icons/eye-off';
+	import Copy from '@lucide/svelte/icons/copy';
+	import ChevronDown from '@lucide/svelte/icons/chevron-down';
 
 	let open = $state(false);
 
@@ -25,6 +34,9 @@
 
 	let selectedTab = $state<'extension' | 'simple' | 'remote'>('extension');
 	let privateKey = $state('');
+	let showPrivateKey = $state(false);
+	let nickname = $state('');
+	let nameExpanded = $state(false);
 	let bunkerUri = $state('');
 	let nostrConnectUri = $state('');
 	let loading = $state(false);
@@ -42,6 +54,7 @@
 
 			manager.addAccount(account);
 			manager.setActive(account);
+			toast.success('Logged in successfully');
 
 			open = false;
 		} catch (err) {
@@ -49,6 +62,13 @@
 		} finally {
 			loading = false;
 		}
+	}
+
+	function resetSimpleState() {
+		privateKey = '';
+		showPrivateKey = false;
+		nickname = '';
+		nameExpanded = false;
 	}
 
 	async function connectSimple() {
@@ -61,14 +81,28 @@
 			loading = true;
 			error = '';
 
-			const signer = SimpleAccount.fromKey(privateKey.trim());
-			const account = new SimpleAccount(signer.pubkey, signer.signer);
+			const signer = PrivateKeyAccount.fromKey(privateKey.trim());
+			const account = new PrivateKeyAccount(signer.pubkey, signer.signer);
+
+			if (nickname.trim()) {
+				const event = finalizeEvent(
+					{
+						kind: Metadata,
+						created_at: Math.floor(Date.now() / 1000),
+						tags: [],
+						content: JSON.stringify({ name: nickname.trim() })
+					},
+					account.signer.key
+				);
+				relayPool.publish(metadataRelays, event);
+			}
 
 			manager.addAccount(account);
 			manager.setActive(account);
+			toast.success('Logged in successfully');
 
 			open = false;
-			privateKey = '';
+			resetSimpleState();
 		} catch (err) {
 			error = err instanceof Error ? err.message : 'Failed to connect with private key';
 		} finally {
@@ -79,6 +113,21 @@
 	function generatePrivateKey() {
 		const secretKey = generateSecretKey();
 		privateKey = bytesToHex(secretKey);
+		showPrivateKey = false;
+	}
+
+	function toNsec(key: string): string {
+		if (!key || key.startsWith('nsec')) return key;
+		try {
+			return nsecEncode(hexToBytes(key));
+		} catch {
+			return key;
+		}
+	}
+
+	async function copyPrivateKey() {
+		if (!privateKey) return;
+		await copyToClipboard(toNsec(privateKey));
 	}
 
 	async function generateRemoteSignerUri() {
@@ -110,6 +159,7 @@
 
 			manager.addAccount(account);
 			manager.setActive(account);
+			toast.success('Logged in successfully');
 
 			// Reset state and close dialog
 			resetRemoteSignerState();
@@ -143,6 +193,7 @@
 
 			manager.addAccount(account);
 			manager.setActive(account);
+			toast.success('Logged in successfully');
 
 			// Reset state and close dialog
 			resetRemoteSignerState();
@@ -191,7 +242,13 @@
 	});
 </script>
 
-<Dialog.Root bind:open onOpenChange={() => (dialogState.dialogId = null)}>
+<Dialog.Root
+	bind:open
+	onOpenChange={() => {
+		dialogState.dialogId = null;
+		resetSimpleState();
+	}}
+>
 	<Dialog.Trigger class={buttonVariants({ variant: 'outline' })}>Login</Dialog.Trigger>
 	<Dialog.Content class="sm:max-w-[425px]">
 		<Dialog.Header>
@@ -251,19 +308,74 @@
 				<div class="space-y-4">
 					<div class="space-y-2">
 						<Label for="account-private-key">Private Key</Label>
-						<div class="flex gap-2">
-							<Input
-								id="account-private-key"
-								placeholder="Enter your private key (hex format)"
-								bind:value={privateKey}
-								class="flex-1 font-mono"
-								type="password"
-							/>
-							<Button variant="outline" onclick={generatePrivateKey} type="button">Generate</Button>
-						</div>
+						{#if !privateKey}
+							<div class="flex gap-2">
+								<Input
+									id="account-private-key"
+									placeholder="Enter your private key (hex or nsec)"
+									bind:value={privateKey}
+									class="flex-1 font-mono"
+									type="text"
+								/>
+								<Button variant="outline" onclick={generatePrivateKey} type="button">Generate</Button>
+							</div>
+						{:else}
+							<div class="flex gap-2">
+								<div class="relative flex-1">
+									<Input
+										id="account-private-key"
+										value={showPrivateKey ? toNsec(privateKey) : privateKey}
+										readonly
+										class="pr-10 font-mono"
+										type={showPrivateKey ? 'text' : 'password'}
+									/>
+									<button
+										type="button"
+										onclick={() => (showPrivateKey = !showPrivateKey)}
+										class="absolute inset-y-0 right-2 flex items-center text-muted-foreground transition-colors hover:text-foreground"
+										aria-label={showPrivateKey ? 'Hide private key' : 'Show private key'}
+									>
+										{#if showPrivateKey}
+											<EyeOff class="h-4 w-4" />
+										{:else}
+											<Eye class="h-4 w-4" />
+										{/if}
+									</button>
+								</div>
+								<Button
+									variant="outline"
+									size="icon"
+									onclick={copyPrivateKey}
+									type="button"
+									aria-label="Copy private key"
+								>
+									<Copy class="h-4 w-4" />
+								</Button>
+							</div>
+						{/if}
 						<p class="text-xs text-muted-foreground">
 							Your private key will be stored securely in your browser's local storage.
 						</p>
+					</div>
+
+					<!-- Optional name accordion -->
+					<div class="space-y-2">
+						<button
+							type="button"
+							onclick={() => (nameExpanded = !nameExpanded)}
+							class="flex items-center gap-1 text-sm font-medium"
+						>
+							Set a name
+							<span class="text-muted-foreground">(Optional)</span>
+							<ChevronDown
+								class="ml-1 h-4 w-4 text-muted-foreground transition-transform duration-200 {nameExpanded
+									? 'rotate-180'
+									: ''}"
+							/>
+						</button>
+						{#if nameExpanded}
+							<Input placeholder="Enter your name" bind:value={nickname} />
+						{/if}
 					</div>
 				</div>
 			{/if}

--- a/src/lib/components/ProfileCard.svelte
+++ b/src/lib/components/ProfileCard.svelte
@@ -103,4 +103,16 @@
 	<span class="inline align-baseline text-sm font-medium break-words text-foreground">
 		{displayName}
 	</span>
+{:else if !isExtended}
+	<div class="flex items-center gap-2">
+		{@render pfp(pubkey, undefined)}
+		<div class="min-w-0 flex-1">
+			<span class="block truncate text-sm font-semibold">{displayName}</span>
+		</div>
+		{#if canShowLogout}
+			<Button variant="ghost" size="icon" onclick={logout} aria-label="Logout">
+				<LogOut class="h-4 w-4" />
+			</Button>
+		{/if}
+	</div>
 {/if}

--- a/src/lib/services/accountManager.svelte.ts
+++ b/src/lib/services/accountManager.svelte.ts
@@ -3,6 +3,7 @@ import { registerCommonAccountTypes } from 'applesauce-accounts/accounts';
 import { NostrConnectSigner } from 'applesauce-signers/signers';
 import { browser } from '$app/environment';
 import { relayPool } from './relay-pool';
+import { toast } from 'svelte-sonner';
 
 // create an account manager instance
 export const manager = new AccountManager();
@@ -44,4 +45,5 @@ export const logout = () => {
 	// 	localStorage.removeItem('accounts');
 	// }
 	manager.clearActive();
+	toast.success('Logged out successfully');
 };

--- a/src/lib/stores/relay-store.svelte.ts
+++ b/src/lib/stores/relay-store.svelte.ts
@@ -3,8 +3,7 @@ import { defaultRelays, devRelay } from '../services/relay-pool';
 
 // Reactive relay store using Svelte 5 $state
 export const relayStore = $state({
-	// selectedRelays: dev ? devRelay : defaultRelays,
-	selectedRelays: defaultRelays,
+	selectedRelays: dev ? devRelay : defaultRelays,
 	relayChangeCallback: null as ((relays: string[]) => void) | null
 });
 

--- a/src/lib/stores/relay-store.svelte.ts
+++ b/src/lib/stores/relay-store.svelte.ts
@@ -3,7 +3,8 @@ import { defaultRelays, devRelay } from '../services/relay-pool';
 
 // Reactive relay store using Svelte 5 $state
 export const relayStore = $state({
-	selectedRelays: dev ? devRelay : defaultRelays,
+	// selectedRelays: dev ? devRelay : defaultRelays,
+	selectedRelays: defaultRelays,
 	relayChangeCallback: null as ((relays: string[]) => void) | null
 });
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -89,7 +89,7 @@ export async function copyToClipboard(data: BlobPart, mimeType = 'text/plain') {
 				resolve(navigator.clipboard.writeText(textData));
 			});
 		}
-		toast.success('Copied 👍');
+		toast.success('Copied to clipboard');
 	} catch (e) {
 		toast.error(`Error: ${e}`);
 		console.log(e);


### PR DESCRIPTION
Improves the login flow by implementing changes as proposed in issue #24.

Changes:
- Update login dialog to hold the private key visibility toggle and copy action.
- Addition of an optional name field
- Addition of fallback logic for rendering null profiles
- Addition of success messages to be displayed as a toast upon successful login.

Outcomes: 
- Enables flexible management and ownership of private keys for the user
- Fallback logic handles rendering of null profiles & delay in fetching metadata events 
- Success messages convey state to the user and ensure visual confirmation

I have attached the screenshots and video of the implementation for reference. Let me know if there are any further refinements or additions required.

|Empty State Login Dialog| Filled State (Private key + optional Name field) | Compact mode rendering of null profiles | Compact mode rendering of non-null profiles|
|:--:|:--:|:--:|:--:|
|<img width="380" height="820" alt="Screenshot 2026-04-30 at 2 11 53 AM" src="https://github.com/user-attachments/assets/4459f0a0-7640-49ea-9d09-b832c1282f50" />|<img width="378" height="822" alt="Screenshot 2026-04-30 at 2 12 35 AM" src="https://github.com/user-attachments/assets/c07590a5-c854-4206-b4bc-9ccc24450262" />|<img width="383" height="822" alt="Screenshot 2026-04-30 at 2 25 09 AM" src="https://github.com/user-attachments/assets/f8078617-9055-47b0-82b7-2ddc2d1c0cd4" />|<img width="383" height="822" alt="Screenshot 2026-04-30 at 2 18 29 AM" src="https://github.com/user-attachments/assets/43b1964b-b558-4099-ab5e-db83155da2e9" />|

Implemented flow video:

https://github.com/user-attachments/assets/a183e3eb-f769-4046-a9c4-2a3f3a338399

Resolves #24 